### PR TITLE
Implement public feedback UI

### DIFF
--- a/models/expertFeedback.js
+++ b/models/expertFeedback.js
@@ -20,7 +20,8 @@ const expertFeedbackSchema = new Schema({
     citationExplanation: { type: String, required: false, default: '' },
     answerImprovement: { type: String, required: false, default: '' },
     expertCitationUrl: { type: String, required: false, default: '' },
-    feedback: { type: String, required: false, default: '' }
+    feedback: { type: String, required: false, default: '' },
+    publicFeedbackReason: { type: String, required: false, default: '' }
 }, {
     timestamps: true, versionKey: false,
     id: false,

--- a/src/components/chat/FeedbackComponent.js
+++ b/src/components/chat/FeedbackComponent.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import ExpertRatingComponent from './ExpertRatingComponent.js';
+import PublicFeedbackComponent from './PublicFeedbackComponent.js';
 import { useHasAnyRole } from '../RoleBasedUI.js';
 import '../../styles/App.css';
 import { useTranslations } from '../../hooks/useTranslations.js';
@@ -19,33 +20,31 @@ const FeedbackComponent = ({
   const { t } = useTranslations(lang);
   const [feedbackGiven, setFeedbackGiven] = useState(false);
   const [showExpertRating, setShowExpertRating] = useState(false);
+  const [showPublicRating, setShowPublicRating] = useState(false);
+  const [publicPositive, setPublicPositive] = useState(true);
   const hasExpertRole = useHasAnyRole(['admin', 'partner']);
 
   const handleFeedback = (isPositive) => {
     let expertFeedback = null;
     if (isPositive) {
-      expertFeedback = {
-        totalScore: 100,
-        type: hasExpertRole ? 'expert' : 'public',
-        isPositive: true,
-      };
-      
-      DataStoreService.persistFeedback(expertFeedback, chatId, userMessageId);
-      setFeedbackGiven(true);
-    } else {
-      
       if (hasExpertRole) {
-        setShowExpertRating(true);
-        
-      } else {
-        // For negative feedback from non-expert
         expertFeedback = {
-          totalScore: 0,
-          type: 'public',
-          isPositive: false,
+          totalScore: 100,
+          type: 'expert',
+          isPositive: true,
         };
         DataStoreService.persistFeedback(expertFeedback, chatId, userMessageId);
         setFeedbackGiven(true);
+      } else {
+        setPublicPositive(true);
+        setShowPublicRating(true);
+      }
+    } else {
+      if (hasExpertRole) {
+        setShowExpertRating(true);
+      } else {
+        setPublicPositive(false);
+        setShowPublicRating(true);
       }
     }
   };
@@ -58,6 +57,11 @@ const FeedbackComponent = ({
     setFeedbackGiven(true);
     setShowExpertRating(false);
     DataStoreService.persistFeedback(feedbackWithType, chatId, userMessageId);
+  };
+
+  const handlePublicFeedback = (publicFeedback) => {
+    setFeedbackGiven(true);
+    setShowPublicRating(false);
   };
 
   if (feedbackGiven) {
@@ -76,6 +80,18 @@ const FeedbackComponent = ({
         lang={lang}
         sentenceCount={sentenceCount}
         sentences={sentences}
+      />
+    );
+  }
+
+  if (showPublicRating) {
+    return (
+      <PublicFeedbackComponent
+        lang={lang}
+        isPositive={publicPositive}
+        chatId={chatId}
+        userMessageId={userMessageId}
+        onSubmit={handlePublicFeedback}
       />
     );
   }

--- a/src/components/chat/PublicFeedbackComponent.js
+++ b/src/components/chat/PublicFeedbackComponent.js
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import '../../styles/App.css';
+import { useTranslations } from '../../hooks/useTranslations.js';
+import DataStoreService from '../../services/DataStoreService.js';
+
+const PublicFeedbackComponent = ({
+  lang = 'en',
+  isPositive = true,
+  chatId,
+  userMessageId,
+  onSubmit = () => {},
+}) => {
+  const { t } = useTranslations(lang);
+  const [selected, setSelected] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  const options = isPositive
+    ? [
+        { id: 'noCall', score: 1, label: t('homepage.publicFeedback.yes.options.noCall') },
+        { id: 'noVisit', score: 2, label: t('homepage.publicFeedback.yes.options.noVisit') },
+        { id: 'savedTime', score: 3, label: t('homepage.publicFeedback.yes.options.savedTime') },
+        { id: 'other', score: 4, label: t('homepage.publicFeedback.yes.options.other') },
+      ]
+    : [
+        { id: 'irrelevant', score: 9, label: t('homepage.publicFeedback.no.options.irrelevant') },
+        { id: 'confusing', score: 8, label: t('homepage.publicFeedback.no.options.confusing') },
+        { id: 'notDetailed', score: 7, label: t('homepage.publicFeedback.no.options.notDetailed') },
+        { id: 'notWanted', score: 5, label: t('homepage.publicFeedback.no.options.notWanted') },
+        { id: 'other', score: 6, label: t('homepage.publicFeedback.no.options.other') },
+      ];
+
+  const surveyUrl = isPositive
+    ? t('homepage.publicFeedback.yes.surveyUrl')
+    : t('homepage.publicFeedback.no.surveyUrl');
+
+  const handleSend = () => {
+    if (!selected) return;
+
+    const option = options.find((o) => o.id === selected);
+    const feedback = {
+      type: 'public',
+      isPositive,
+      totalScore: option.score,
+      publicFeedbackReason: selected,
+    };
+    DataStoreService.persistFeedback(feedback, chatId, userMessageId);
+    setSubmitted(true);
+    onSubmit(feedback);
+  };
+
+  if (submitted) {
+    return (
+      <p className="thank-you">
+        <span className="gcds-icon fa fa-solid fa-check-circle"></span>
+        {t('homepage.feedback.thankYou')}
+      </p>
+    );
+  }
+
+  return (
+    <div className="feedback-container">
+      <p>
+        {isPositive
+          ? t('homepage.publicFeedback.yes.question')
+          : t('homepage.publicFeedback.no.question')}
+      </p>
+      <fieldset className="gc-chckbxrdio sm-v">
+        <ul className="list-unstyled lst-spcd-2">
+          {options.map((opt) => (
+            <li className="radio" key={opt.id}>
+              <input
+                type="radio"
+                id={opt.id}
+                value={opt.id}
+                checked={selected === opt.id}
+                onChange={() => setSelected(opt.id)}
+              />
+              <label htmlFor={opt.id}>{opt.label}</label>
+            </li>
+          ))}
+        </ul>
+      </fieldset>
+      <a
+        href={surveyUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="feedback-survey-link"
+      >
+        {t('homepage.publicFeedback.surveyLink')}
+      </a>
+      <button onClick={handleSend} className="btn-primary mrgn-lft-sm">
+        {t('homepage.publicFeedback.send')}
+      </button>
+    </div>
+  );
+};
+
+export default PublicFeedbackComponent;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -40,6 +40,31 @@
       "or": "or",
       "thankYou": "Thank you for your feedback!"
     },
+    "publicFeedback": {
+      "surveyLink": "Tell us more! AI Answers feedback survey (opens in new tab)",
+      "send": "Send",
+      "yes": {
+        "question": "Why was it helpful? Select the best option below. (required)",
+        "surveyUrl": "https://cdssnc.qualtrics.com/jfe/form/SV_4N2YTcAHkcBEGfs/?so=pub&cl=y",
+        "options": {
+          "noCall": "I don't need to call the government",
+          "noVisit": "I don't need to visit an office",
+          "savedTime": "Saved me time searching and reading",
+          "other": "Other - please fill out the survey"
+        }
+      },
+      "no": {
+        "question": "Why wasn't it helpful? Select the best option below. (required)",
+        "surveyUrl": "https://cdssnc.qualtrics.com/jfe/form/SV_4N2YTcAHkcBEGfs/?so=pub&cl=n",
+        "options": {
+          "irrelevant": "Irrelevant or off topic",
+          "confusing": "Too complex or confusing",
+          "notDetailed": "Not detailed enough",
+          "notWanted": "Answer is clear, but is not what I wanted to hear",
+          "other": "Other - please fill out the survey"
+        }
+      }
+    },
     "privacy": {
       "title": "Privacy and AI terms of use",
       "storage": "To protect your privacy, questions containing personal information (like phone numbers or email addresses) are blocked. You'll see sensitive content marked with XXX and be asked to rephrase. Blocked questions are not sent to our AI service or stored. All other questions, answers and your feedback are stored to improve system performance.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -40,6 +40,31 @@
       "or": "ou",
       "thankYou": "Merci d'avoir donné votre avis!"
     },
+    "publicFeedback": {
+      "surveyLink": "Dites-nous en plus! Enquête d'évaluation (s'ouvre dans un nouvel onglet)",
+      "send": "Envoyer",
+      "yes": {
+        "question": "Pourquoi était-ce utile ? Sélectionnez la meilleure option ci-dessous. (obligatoire)",
+        "surveyUrl": "https://cdssnc.qualtrics.com/jfe/form/SV_4N2YTcAHkcBEGfs?Q_Language=FR-CA&so=pub&cl=y",
+        "options": {
+          "noCall": "Je n'ai pas besoin d'appeler le gouvernement",
+          "noVisit": "Je n'ai pas besoin de me rendre dans un bureau",
+          "savedTime": "J'ai gagné du temps en cherchant et en lisant",
+          "other": "Autre - veuillez remplir l'enquête"
+        }
+      },
+      "no": {
+        "question": "Pourquoi n'était-ce pas utile ? Sélectionnez la meilleure option ci-dessous. (obligatoire)",
+        "surveyUrl": "https://cdssnc.qualtrics.com/jfe/form/SV_4N2YTcAHkcBEGfs?Q_Language=FR-CA&so=pub&cl=n",
+        "options": {
+          "irrelevant": "Non pertinent ou hors sujet",
+          "confusing": "Trop complexe ou confus",
+          "notDetailed": "Pas assez détaillé",
+          "notWanted": "La réponse est claire, mais ce n'est pas ce que je voulais entendre",
+          "other": "Autre - veuillez remplir l'enquête"
+        }
+      }
+    },
     "privacy": {
       "title": "Confidentialité et conditions d'utilisation de l'IA",
       "storage": "Pour protéger votre vie privée, les questions contenant des renseignements personnels (comme des numéros de téléphone ou des adresses courriel) sont bloquées. Vous verrez le contenu sensible marqué avec XXX et il vous sera demandé de reformuler. Les questions bloquées ne sont pas envoyées à notre service d'IA ni stockées. Toutes les autres questions, réponses et vos commentaires sont stockés pour améliorer les performances du système.",

--- a/src/services/DataStoreService.js
+++ b/src/services/DataStoreService.js
@@ -99,7 +99,8 @@ class DataStoreService {
         citationScore: expertFeedback.citationScore ?? null,
         answerImprovement: expertFeedback.answerImprovement || '',
         expertCitationUrl: expertFeedback.expertCitationUrl || '',
-        feedback: expertFeedback.isPositive ? 'positive' : 'negative'
+        feedback: expertFeedback.isPositive ? 'positive' : 'negative',
+        publicFeedbackReason: expertFeedback.publicFeedbackReason || ''
       };
     }
     console.log('User feedback:', JSON.stringify(formattedExpertFeedback, null, 2));


### PR DESCRIPTION
## Summary
- add new PublicFeedbackComponent for unauthenticated users
- persist chosen public feedback reason
- update FeedbackComponent to display expert/public flows
- extend ExpertFeedback model and persistence service
- include English and French translations for public feedback survey

## Testing
- `npm test` *(fails: RollupError due to JSX parsing and missing mocks)*

------
https://chatgpt.com/codex/tasks/task_b_683da39c9e84832eb9158398e56a0725