### PR TITLE
Replace polling with manual refresh in ChatViewer

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -265,9 +265,9 @@
   },
   "logging": {
     "title": "Chat Viewer",
-    "start": "Start",
-    "pause": "Pause"
-  },  "admin": {
+    "refresh": "Refresh"
+  },
+  "admin": {
     "title": "AI Answers Admin dashboard",
     "navigation": {
       "ariaLabel": "Admin Navigation",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -267,8 +267,7 @@
   },
   "logging": {
     "title": "Visualiseur de chat",
-    "start": "Démarrer",
-    "pause": "Pause"
+    "refresh": "Actualiser"
   },
   "admin": {
     "title": "Tableau de bord d'administration de Réponses IA",


### PR DESCRIPTION
## Summary
- remove log polling from `ChatViewer`
- add manual refresh button for retrieving logs
- update translations

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'mockResolvedValue'))*

------
https://chatgpt.com/codex/tasks/task_b_684b3e050218832e86b2764f960b0543